### PR TITLE
cloudformation-codebase/EC2-instance.yaml is added

### DIFF
--- a/cloudformation-codebase/EC2-instance.yaml
+++ b/cloudformation-codebase/EC2-instance.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: This CloudFormation template is intended for testing purposes. It provisions
+  a single Amazon EC2 instance of type t2.micro using a specified KeyPair to
+  allow SSH access. The template is useful for beginners to understand how
+  CloudFormation works and how to structure a basic EC2 deployment using YAML.
+
+Resources:
+  NewEC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-020cba7c55df1f615
+      InstanceType: t2.micro
+      KeyName: 22042025linux
+      SecurityGroupIds: 
+        - sg-0ab0472d009ff7177
+      Tags: 
+        - Key: Name
+          Value: testInstance
+      
+
+


### PR DESCRIPTION
This CloudFormation YAML template provisions a single Amazon EC2 instance of type t2.micro using a specified AMI and KeyPair. It attaches an existing security group for managing network access and applies a name tag to the instance. This template is ideal for beginners to understand the basics of launching an EC2 instance using AWS CloudFormation.